### PR TITLE
Global scope added

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -3,6 +3,7 @@ const path = require('path')
 module.exports = {
   entry: path.resolve(__dirname, 'src/index.js'),
   output: {
+    globalObject: 'this',
     path: path.resolve(__dirname, 'dist'),
     filename: 'main.js',
     library: 'OpenTenderRedux',


### PR DESCRIPTION
This avoids a reference error during server-side rendering and static exporting. For reference https://webpack.js.org/configuration/output/#outputglobalobject
I tested on the Skeleton app, and it didn't cause any issue